### PR TITLE
Feat/add show help function

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A custom Discord bot designed for the Jirai sweeties server, combining chat functionality with automated store monitoring.
 
 ## Project Information
-- **Version**: 1.3.0
+- **Version**: 1.4.0
 - **Author**: [yumeangelica](https://github.com/yumeangelica)
 - **License**: [CC BY-NC-ND 4.0](LICENSE.txt)
 - **Repository**: [Jirai sweeties](https://github.com/yumeangelica/jirai_sweeties)


### PR DESCRIPTION
This PR adds a `!help` command and refactors embed color handling in `DiscordBot`.
- Added `!help` command with a detailed help message.
- Implemented `show_help` function to display bot features and commands.
- Refactored embed color validation into `get_embed_color` for reusability.
- Bumped minor version to 1.4.0.